### PR TITLE
Release keys when Gopher is disabled

### DIFF
--- a/Windows/Gopher/Gopher.cpp
+++ b/Windows/Gopher/Gopher.cpp
@@ -769,6 +769,9 @@ HWND Gopher::getOskWindow()
 // Description:
 //   Removes an entry for a pressed key from the list.
 //
+// Params:
+//   key  The key value to remove from the pressed key list. 
+//
 // Returns:
 //   True if the given key was found and removed from the list.
 bool Gopher::erasePressedKey(WORD key)

--- a/Windows/Gopher/Gopher.cpp
+++ b/Windows/Gopher/Gopher.cpp
@@ -367,8 +367,36 @@ void Gopher::handleDisableButton()
 
     if (_disabled)
     {
+      // Transition to a disabled state.
       duration = 400;
       intensity = 10000;
+
+      // Release all keys currently pressed by the Gopher mapping.
+      while (_pressedKeys.size() != 0)
+      {
+        std::list<WORD>::iterator it = _pressedKeys.begin();
+
+        // Handle mouse buttons
+        if (*it == VK_LBUTTON)
+        {
+          mouseEvent(MOUSEEVENTF_LEFTUP);
+        }
+        else if (*it == VK_RBUTTON)
+        {
+          mouseEvent(MOUSEEVENTF_RIGHTUP);
+        }
+        else if (*it == VK_MBUTTON)
+        {
+          mouseEvent(MOUSEEVENTF_MIDDLEUP);
+        }
+        // Handle keys (TODO: support mouse X1 and X2 buttons)
+        else
+        {
+          inputKeyboardUp(*it);
+        }
+
+        _pressedKeys.erase(it);
+      }
     }
     else
     {
@@ -634,11 +662,17 @@ void Gopher::mapKeyboard(DWORD STATE, WORD key)
   if (_xboxClickIsDown[STATE])
   {
     inputKeyboardDown(key);
+
+    // Add key to the list of pressed keys.
+    _pressedKeys.push_back(key);
   }
 
   if (_xboxClickIsUp[STATE])
   {
     inputKeyboardUp(key);
+
+    // Remove key from the list of pressed keys.
+    erasePressedKey(key);
   }
 }
 
@@ -655,11 +689,39 @@ void Gopher::mapMouseClick(DWORD STATE, DWORD keyDown, DWORD keyUp)
   if (_xboxClickIsDown[STATE])
   {
     mouseEvent(keyDown);
+
+    // Add key to the list of pressed keys.
+    if (keyDown == MOUSEEVENTF_LEFTDOWN)
+    {
+      _pressedKeys.push_back(VK_LBUTTON);
+    }
+    else if (keyDown == MOUSEEVENTF_RIGHTDOWN)
+    {
+      _pressedKeys.push_back(VK_RBUTTON);
+    }
+    else if (keyDown == MOUSEEVENTF_MIDDLEDOWN)
+    {
+      _pressedKeys.push_back(VK_MBUTTON);
+    }
   }
 
   if (_xboxClickIsUp[STATE])
   {
     mouseEvent(keyUp);
+
+    // Remove key from the list of pressed keys.
+    if (keyUp == MOUSEEVENTF_LEFTUP)
+    {
+      erasePressedKey(VK_LBUTTON);
+    }
+    else if (keyUp == MOUSEEVENTF_RIGHTUP)
+    {
+      erasePressedKey(VK_RBUTTON);
+    }
+    else if (keyUp == MOUSEEVENTF_MIDDLEUP)
+    {
+      erasePressedKey(VK_MBUTTON);
+    }
   }
 
   /*if (_xboxClickIsDownLong[STATE])
@@ -702,4 +764,25 @@ HWND Gopher::getOskWindow()
   HWND ret = NULL;
   EnumWindows(EnumWindowsProc, (LPARAM)&ret);
   return ret;
+}
+
+// Description:
+//   Removes an entry for a pressed key from the list.
+//
+// Returns:
+//   True if the given key was found and removed from the list.
+bool Gopher::erasePressedKey(WORD key)
+{
+  for (std::list<WORD>::iterator it = _pressedKeys.begin();
+       it != _pressedKeys.end();
+       ++it)
+  {
+    if (*it == key)
+    {
+      _pressedKeys.erase(it);
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/Windows/Gopher/Gopher.h
+++ b/Windows/Gopher/Gopher.h
@@ -1,6 +1,7 @@
 #include <windows.h> // for Beep()
 #include <iostream>
 #include <vector>
+#include <list>
 #include <xinput.h> // controller
 #include <stdio.h> // for printf
 #include <cmath> // for abs()
@@ -20,7 +21,7 @@ private:
   int DEAD_ZONE = 6000;                 // Thumbstick dead zone to use for mouse movement. Absolute maximum shall be 65534.
   int SCROLL_DEAD_ZONE = 5000;          // Thumbstick dead zone to use for scroll wheel movement. Absolute maximum shall be 65534.
   int TRIGGER_DEAD_ZONE = 0;            // Dead zone for the left and right triggers to detect a trigger press. 0 means that any press to trigger will be read as a button press.
-  float SCROLL_SPEED = 0.1;             // Speed at which you scroll.
+  float SCROLL_SPEED = 0.1f;             // Speed at which you scroll.
   const int FPS = 150;                  // Update rate of the main Gopher loop. Interpreted as cycles-per-second.
   const int SLEEP_AMOUNT = 1000 / FPS;  // Number of milliseconds to sleep per iteration.
 
@@ -45,7 +46,7 @@ private:
 
   std::vector<float> speeds;	            // Contains actual speeds to choose
   std::vector<std::string> speed_names;   // Contains display names of speeds to display
-  int speed_idx = 0;
+  unsigned int speed_idx = 0;
 
   // Mouse Clicks
   DWORD CONFIG_MOUSE_LEFT = NULL;
@@ -83,6 +84,8 @@ private:
   std::map<DWORD, bool> _xboxClickIsDownLong;
   std::map<DWORD, int> _xboxClickDownLength;
   std::map<DWORD, bool> _xboxClickIsUp;
+
+  std::list<WORD> _pressedKeys;
 
   CXBOXController* _controller;
 
@@ -123,4 +126,8 @@ public:
   void setXboxClickState(DWORD state);
 
   HWND getOskWindow();
+
+private:
+
+  bool erasePressedKey(WORD key);
 };


### PR DESCRIPTION
When disabling Gopher, any buttons that were being pushed would cause the mapped key to remain being pressed down when Gopher is in the disabled state. This is very apparent with the default configuration. If the Start button is pressed down followed by the Back button, the Windows key (as a result of the Start button being pressed) will be pressed down followed by Gopher being disabled. Since Gopher is disabled and already sent the Windows key down event, when the Start button is released, the Windows key up event is not sent. Therefore, key presses after the fact will result in Win+[Key] commands being sent.

See issue https://github.com/Tylemagne/Gopher360/issues/80.