### PR TITLE
extend default config and fix scrolling

### DIFF
--- a/Windows/Gopher/ConfigFile.cpp
+++ b/Windows/Gopher/ConfigFile.cpp
@@ -142,6 +142,10 @@ void ConfigFile::ExtractKeys()
     outfile << "# ACCELERATION_FACTOR = 3" << std::endl;
     outfile << "#  Swaps the function of the thumbsticks. Set to 0 for default behavior or set to 1 to have the mouse movement on the right stick and scrolling on the left stick." << std::endl;
     outfile << "SWAP_THUMBSTICKS = 0" << std::endl;
+    outfile << "DEAD_ZONE = 6000 # Thumbstick dead zone to use for mouse movement. Absolute maximum thumbstick value is 32768." << std::endl;
+    outfile << "SCROLL_DEAD_ZONE = 5000 # Thumbstick dead zone to use for scroll wheel movement. Absolute maximum thumbstick value is 32768." << std::endl;
+    outfile << "TRIGGER_DEAD_ZONE = 0 # Dead zone for the left and right triggers to detect a trigger press. Range from 0 (accept all input) to 255 (ignore all input)." << std::endl;
+    outfile << "SCROLL_SPEED = 0.1 # Speed at which you scroll (scalar)" << std::endl;
     // End config dump
 
     outfile.close();

--- a/Windows/Gopher/main.cpp
+++ b/Windows/Gopher/main.cpp
@@ -42,6 +42,8 @@ BOOL isRunningAsAdministrator(); // Check if administrator, makes on-screen keyb
 
 int main()
 {
+  char* buildDate = "2021-01-20";
+
   CXBOXController controller(1);
   Gopher gopher(&controller);
   HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -49,7 +51,7 @@ int main()
 
   system("Color 1D");
 
-  printf("Welcome to Gopher360 - a VERY fast and lightweight controller-to-keyboard & mouse input tool.\n");
+  printf("Welcome to Gopher360 (built %s) - a VERY fast and lightweight controller-to-keyboard & mouse input tool.\n", buildDate);
   printf("All you need is an Xbox360/Xbone controller (wired or wireless adapter), or DualShock (with InputMapper 1.5+)\n");
   printf("Gopher will autofind the xinput device and begin reading input - if nothing happens, verify connectivity.\n");
   printf("See the GitHub repository at bit.ly/1syAhMT for more info. Twitter contact: TylerAt60FPS\n\n-------------------------\n\n");


### PR DESCRIPTION
- added missing (but available) parameters to default config 
    - Stuff like DEAD_ZONE, SCROLL_DEAD_ZONE, TRIGGER_DEAD_ZONE and SCROLL_SPEED is already implemented but was not documented.
- fix scrolling: must be an int
    - before, a float was passed to mouseEvent(...) which was causing issues.
- apply getDelta(...) to tx and ty before any calculation is done
    -  otherwise some calculations could have been done with wrong value already
- pass magnitude to getMult instead of lengthsq
    - magnitude calculation can be simpler for scrolling because dimensions (X and Y) are handled independently (in this case magnitude is abs(deltaValue))
- main.cpp : added (hard coded) build date to console output 
    - motivation: I did not find any version information. This is needed to let users know which parameters are available and what is (not) working in their version.