### PR TITLE
Fixed bottom-left deadzone

### DIFF
--- a/Windows/Gopher/Gopher.cpp
+++ b/Windows/Gopher/Gopher.cpp
@@ -522,7 +522,7 @@ void Gopher::handleMouseMovement()
   float dy = 0;
 
   // Handle dead zone
-  float lengthsq = tx * tx + ty * ty;
+  float lengthsq = unsigned int(tx * tx + ty * ty);
   if (lengthsq > DEAD_ZONE * DEAD_ZONE)
   {
     float mult = speed * getMult(lengthsq, DEAD_ZONE, acceleration_factor);


### PR DESCRIPTION
There used to be a problem where moving the joystick to bottom-left will not make the cursor move. This was caused by an overflow in the calculation of lengthsq in handleMouseMovement. I added unsigned int to solve it.