### PR TITLE
Added config flag to optionally start disabled

### DIFF
--- a/Configs/config_default.ini
+++ b/Configs/config_default.ini
@@ -4,6 +4,11 @@
 #	SET 0 FOR NO FUNCTION
 #	TIP: Sum the hex value for double button shortcuts eg. 0x0010(START) 0x0020(BACK) so 0x0030(START+BACK) will trigger the event only when both are pressed.
 
+#	Startup configuration (0 = false, 1 or any other value = true)
+
+INIT_DISABLED_ON_START = 0x0 # Determines whether the gamepad controls mouse/keyboard input on starting Gopher
+
+#	Map buttons to actions
 
 CONFIG_MOUSE_LEFT = 0x1000	# Left mouse button
 CONFIG_MOUSE_RIGHT = 0x4000	# Right mouse button

--- a/Windows/Gopher/ConfigFile.cpp
+++ b/Windows/Gopher/ConfigFile.cpp
@@ -104,7 +104,13 @@ void ConfigFile::ExtractKeys()
     outfile << "#	SET 0 FOR NO FUNCTION." << std::endl;
     outfile << "#	AVAILABLE VALUES AT https://msdn.microsoft.com/en-us/library/windows/desktop/microsoft.directx_sdk.reference.xinput_gamepad(v=vs.85).aspx" << std::endl;
     outfile << "#	TIP: Sum the hex value for double button shortcuts eg. 0x0010(START) 0x0020(BACK) so 0x0030(START+BACK) will trigger the event only when both are pressed." << std::endl;
-    outfile << "\n" << std::endl;
+    outfile << std::endl;
+    outfile << "#	Startup configuration (0 = false, 1 or any other value = true)" << std::endl;
+    outfile << std::endl;
+    outfile << "INIT_DISABLED_ON_START = 0x0 # Determines whether the gamepad controls mouse / keyboard input on starting Gopher" << std::endl;
+    outfile << std::endl;
+    outfile << "#	Map buttons to actions" << std::endl;
+    outfile << std::endl;
     outfile << "CONFIG_MOUSE_LEFT = 0x1000	# Left mouse button" << std::endl;
     outfile << "CONFIG_MOUSE_RIGHT = 0x4000	# Right mouse button" << std::endl;
     outfile << "CONFIG_MOUSE_MIDDLE = 0x0040	# Middle mouse button" << std::endl;

--- a/Windows/Gopher/Gopher.cpp
+++ b/Windows/Gopher/Gopher.cpp
@@ -81,7 +81,13 @@ Gopher::Gopher(CXBOXController * controller)
 void Gopher::loadConfigFile()
 {
   ConfigFile cfg("config.ini");
-  
+
+  //--------------------------------
+  // Startup configuration
+  //--------------------------------
+    
+  _disabled = strtol(cfg.getValueOfKey<std::string>("INIT_DISABLED_ON_START").c_str(), 0, 0) != 0;
+
   //--------------------------------
   // Configuration bindings
   //--------------------------------

--- a/Windows/Gopher/Gopher.vcxproj
+++ b/Windows/Gopher/Gopher.vcxproj
@@ -15,21 +15,21 @@
     <ProjectGuid>{896B8CDE-8FC8-42F3-AC14-FA6D202DBBD7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Gopher</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Adds a new INIT_DISABLED_ON_START option in the config file
The default value preserves the current behaviour

With this change, Gopher can be configured to start in disabled mode.

This is useful when gopher is only sometimes needed so its mouse/keyboard control becomes opt-in rather than opt-out