### PR TITLE
Add option SCROLL_FLIPFLOP to reverse scroll direction

### DIFF
--- a/Windows/Gopher/Gopher.cpp
+++ b/Windows/Gopher/Gopher.cpp
@@ -187,6 +187,9 @@ void Gopher::loadConfigFile()
   // Swap stick functions
   SWAP_THUMBSTICKS = strtol(cfg.getValueOfKey<std::string>("SWAP_THUMBSTICKS").c_str(), 0, 0);
 
+  // Flip-flop scroll direction
+  SCROLL_FLIPFLOP = strtol(cfg.getValueOfKey<std::string>("SCROLL_FLIPFLOP").c_str(), 0, 0);
+
   // Set the initial window visibility
   setWindowVisibility(_hidden);
 }
@@ -561,12 +564,21 @@ void Gopher::handleScrolling()
   }
 
   // Handle dead zone
-  float magnitude = sqrt(tx * tx + ty * ty);
+  float txSq = tx * tx;
+  float tySq = ty * ty;
+  float magnitude = sqrt(txSq + tySq);
 
   if (magnitude > SCROLL_DEAD_ZONE)
   {
-    mouseEvent(MOUSEEVENTF_HWHEEL, tx * getMult(tx * tx, SCROLL_DEAD_ZONE) * SCROLL_SPEED);
-    mouseEvent(MOUSEEVENTF_WHEEL, ty * getMult(ty * ty, SCROLL_DEAD_ZONE) * SCROLL_SPEED);
+    // scroll one direction at a time, either horizontally or vertically
+    if (tySq > txSq)
+    {
+        mouseEvent(MOUSEEVENTF_WHEEL, (SCROLL_FLIPFLOP ? -ty : ty) * getMult(tySq, SCROLL_DEAD_ZONE) * SCROLL_SPEED);
+    }
+    else
+    {
+        mouseEvent(MOUSEEVENTF_HWHEEL, (SCROLL_FLIPFLOP ? -tx : tx) * getMult(txSq, SCROLL_DEAD_ZONE) * SCROLL_SPEED);
+    }
   }
 }
 

--- a/Windows/Gopher/Gopher.h
+++ b/Windows/Gopher/Gopher.h
@@ -25,6 +25,7 @@ private:
   const int FPS = 150;                  // Update rate of the main Gopher loop. Interpreted as cycles-per-second.
   const int SLEEP_AMOUNT = 1000 / FPS;  // Number of milliseconds to sleep per iteration.
   int SWAP_THUMBSTICKS = 0;             // Swaps the function of the thumbsticks when not equal to 0.
+  int SCROLL_FLIPFLOP = 0;              // Flip-flop scroll direction when not equal to 0.
 
   XINPUT_STATE _currentState;
 


### PR DESCRIPTION
What's new:
Set option SCROLL_FLIPFLOP = 1 in config.ini to reverse scroll direction.

Changed:
Scroll one direction at a time, either horizontally or vertically.